### PR TITLE
[COD-41] Updated randomizer-results-pair-text and changed headings into h1 tags

### DIFF
--- a/client/src/components/utilities/Randomizer.js
+++ b/client/src/components/utilities/Randomizer.js
@@ -49,9 +49,9 @@ export default () => {
   return (
     <div className="randomizer-container">
       <div>
-        <div className="randomizer-names-heading">
+        <h1 className="randomizer-names-heading">
           Names
-        </div>
+        </h1>
 
         <div className="randomizer-names-container">
           {
@@ -96,9 +96,9 @@ export default () => {
 
       <div className="randomizer-results-container">
         <div>
-          <div className="randomizer-results-heading">
+          <h1 className="randomizer-results-heading">
             Results
-          </div>
+          </h1>
 
           <div className="randomizer-results-wrapper">
             {

--- a/client/src/styles/Randomizer.scss
+++ b/client/src/styles/Randomizer.scss
@@ -11,8 +11,6 @@
 }
 
 .randomizer-names-heading {
-  padding-top: 10px;
-  padding-bottom: 10px;
   text-align: center;
 }
 
@@ -96,8 +94,6 @@
 }
 
 .randomizer-results-heading {
-  padding-top: 20px;
-  padding-bottom: 10px;
   text-align: center;
 }
 
@@ -129,10 +125,11 @@
 }
 
 .randomizer-results-pair-text {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  text-align: center;
+}
+
+.randomizer-results-pair-text + .randomizer-results-pair-text {
+  padding-top: .5em;
 }
 
 .randomizer-results-assigned-task {


### PR DESCRIPTION
Fixes [COD-41]

Changes proposed in this pull request:
- Removed unused css styles on randomizer-results-pair-text class and added padding to the top
- Changed heading div tags into h1 tags and removed the padding on the class since h1 tags have natural margins top and bottom.  This also makes those heading more known.

