### PR TITLE
[COD-51] Changed NavLink Name, removed debugger, Fixed styles slot/randomizer

### DIFF
--- a/client/src/components/nav/UtilitiesLinks.js
+++ b/client/src/components/nav/UtilitiesLinks.js
@@ -8,7 +8,7 @@ export default () => {
         <NavLink exact to="/utilities" className="link">Utilities</NavLink>
       </div>
       <div className="link-wrapper">
-        <NavLink to="/utilities/bigwinner" className="link">Big Winner</NavLink>
+        <NavLink to="/utilities/bigwinner" className="link">Winner</NavLink>
       </div>
       <div className="link-wrapper">
         <NavLink to="/utilities/randomizer" className="link">Randomizer</NavLink>

--- a/client/src/components/utilities/BigWinner.js
+++ b/client/src/components/utilities/BigWinner.js
@@ -23,7 +23,6 @@ export default () => {
         
         let counter = 0;
         let rollInterval = setInterval(function () {
-            debugger;
             if (counter < names.length) {
                 setWinner(names[counter]);
                 counter++;

--- a/client/src/styles/BigWinner.scss
+++ b/client/src/styles/BigWinner.scss
@@ -1,5 +1,5 @@
 .SlotMachine {
-    padding: 100px;
+    margin-top: 2em;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -22,7 +22,7 @@
 
             .fruit-container {
                 position: absolute;
-                top: 15px;
+                top: 30px;
                 width: 100%;
                 text-align: center;
             }

--- a/client/src/styles/Randomizer.scss
+++ b/client/src/styles/Randomizer.scss
@@ -21,7 +21,7 @@
   border-radius: 5px;
   box-shadow: rgba(0, 0, 0, 0.05) 0px 2px 6px 1px;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr) );
   grid-auto-rows: minmax(100px, auto);
   padding-bottom: 20px;
   border: 2px solid rgb(34, 34, 59);
@@ -104,7 +104,7 @@
   border-radius: 5px;
   box-shadow: rgba(0, 0, 0, 0.05) 0px 2px 6px 1px;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr) );
   grid-auto-rows: minmax(100px, 200px);
   padding-bottom: 20px;
   padding-top: 20px;
@@ -154,15 +154,5 @@
   .randomizer-btns-container {
     width: 100%;
     margin-top: 2em;
-  }
-}
-
-@media only screen and (max-width: 730px) {
-  .randomizer-names-container {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .randomizer-results-wrapper {
-    grid-template-columns: 1fr 1fr;
   }
 }


### PR DESCRIPTION
Fixes [COD-51]

Changes proposed in this pull request:
- Changed NavLink name to fit better
- Removed debugger
- Fixed Styles:
  - You couldn't click the slot machine on mobile
  - If you put a long name it would overflow on the names section for mobile.  This was happening on the randomizer as well.  Modified the grid-column styles to fix issues.


[bigWinner quickfix mobile](https://app.gitkraken.com/glo/card/0aff28deb7ea44c7acbebddeb2cbb3c9)