### PR TITLE
Remove node-sass.  Add sass.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,13 +15,13 @@
                 "eslint-config-react-app": "^6.0.0",
                 "howler": "^2.2.3",
                 "moment": "^2.29.1",
-                "node-sass": "5.0.0",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-hook-form": "^7.15.2",
                 "react-router": "^5.2.1",
                 "react-router-dom": "^5.3.0",
-                "react-scripts": "4.0.3"
+                "react-scripts": "4.0.3",
+                "sass": "^1.42.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -3086,7 +3086,9 @@
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/accepts": {
             "version": "1.3.7",
@@ -3208,6 +3210,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.4.2"
             }
@@ -3299,6 +3303,8 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -3357,6 +3363,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3546,6 +3554,8 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
             "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -4293,7 +4303,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "optional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4716,6 +4725,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "camelcase": "^2.0.0",
                 "map-obj": "^1.0.0"
@@ -4728,6 +4739,8 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
             "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4801,7 +4814,6 @@
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
             "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-            "optional": true,
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -5032,6 +5044,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5231,7 +5245,9 @@
         "node_modules/console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "optional": true,
+            "peer": true
         },
         "node_modules/constants-browserify": {
             "version": "1.0.0",
@@ -5884,6 +5900,8 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "array-find-index": "^1.0.1"
             },
@@ -6164,7 +6182,9 @@
         "node_modules/delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "optional": true,
+            "peer": true
         },
         "node_modules/depd": {
             "version": "1.1.2",
@@ -6577,6 +6597,8 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
             "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -8582,6 +8604,8 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -8597,6 +8621,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
             "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "globule": "^1.0.0"
             },
@@ -8650,6 +8676,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
             "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8777,6 +8805,8 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
             "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "glob": "~7.1.1",
                 "lodash": "~4.17.10",
@@ -8863,6 +8893,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -8874,6 +8906,8 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8908,7 +8942,9 @@
         "node_modules/has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "optional": true,
+            "peer": true
         },
         "node_modules/has-value": {
             "version": "1.0.0",
@@ -9731,7 +9767,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "optional": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -9900,6 +9935,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
             "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             },
@@ -9911,6 +9948,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
             },
@@ -10122,7 +10161,9 @@
         "node_modules/is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "optional": true,
+            "peer": true
         },
         "node_modules/is-windows": {
             "version": "1.0.2",
@@ -11415,7 +11456,9 @@
         "node_modules/js-base64": {
             "version": "2.6.4",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-            "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+            "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -11692,6 +11735,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -11818,6 +11863,8 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "currently-unhandled": "^0.4.1",
                 "signal-exit": "^3.0.0"
@@ -11906,6 +11953,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11957,6 +12006,8 @@
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "camelcase-keys": "^2.0.0",
                 "decamelize": "^1.1.2",
@@ -11977,6 +12028,8 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -11989,6 +12042,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "repeating": "^2.0.0"
             },
@@ -12000,6 +12055,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "pinkie-promise": "^2.0.0"
             },
@@ -12011,6 +12068,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -12024,6 +12083,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
@@ -12036,6 +12097,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "indent-string": "^2.1.0",
                 "strip-indent": "^1.0.1"
@@ -12048,6 +12111,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "get-stdin": "^4.0.1"
             },
@@ -12428,7 +12493,9 @@
         "node_modules/nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/nanoid": {
             "version": "3.1.22",
@@ -12524,6 +12591,8 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
             "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.0",
                 "glob": "^7.1.4",
@@ -12547,6 +12616,8 @@
             "version": "7.3.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
             "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -12653,6 +12724,8 @@
             "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
             "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
             "hasInstallScript": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "async-foreach": "^0.1.3",
                 "chalk": "^1.1.1",
@@ -12682,6 +12755,8 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12690,6 +12765,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
@@ -12705,6 +12782,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -12713,6 +12792,8 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
             "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "abbrev": "1"
             },
@@ -12787,6 +12868,8 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -12811,6 +12894,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13354,6 +13439,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -15562,7 +15649,6 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
             "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-            "optional": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -15750,6 +15836,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "is-finite": "^1.0.0"
             },
@@ -16438,10 +16526,26 @@
             "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
             "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
         },
+        "node_modules/sass": {
+            "version": "1.42.1",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+            "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
+            "dependencies": {
+                "chokidar": ">=3.0.0 <4.0.0"
+            },
+            "bin": {
+                "sass": "sass.js"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
         "node_modules/sass-graph": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
             "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "glob": "^7.0.0",
                 "lodash": "^4.0.0",
@@ -16565,6 +16669,8 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "js-base64": "^2.1.8",
                 "source-map": "^0.4.2"
@@ -16574,6 +16680,8 @@
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "amdefine": ">=0.0.4"
             },
@@ -17290,6 +17398,8 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
             "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "readable-stream": "^2.0.1"
             }
@@ -17385,6 +17495,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17479,6 +17591,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "is-utf8": "^0.2.0"
             },
@@ -18165,6 +18279,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
             "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18173,6 +18289,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
             "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.2"
             }
@@ -19871,6 +19989,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2"
             }
@@ -22754,7 +22874,9 @@
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "optional": true,
+            "peer": true
         },
         "accepts": {
             "version": "1.3.7",
@@ -22844,7 +22966,9 @@
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "optional": true,
+            "peer": true
         },
         "ansi-colors": {
             "version": "4.1.1",
@@ -22902,6 +23026,8 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -22947,7 +23073,9 @@
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "optional": true,
+            "peer": true
         },
         "array-flatten": {
             "version": "2.1.2",
@@ -23098,7 +23226,9 @@
         "async-foreach": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+            "optional": true,
+            "peer": true
         },
         "async-limiter": {
             "version": "1.0.1",
@@ -23693,8 +23823,7 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "optional": true
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
         "bluebird": {
             "version": "3.7.2",
@@ -24046,6 +24175,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "camelcase": "^2.0.0",
                 "map-obj": "^1.0.0"
@@ -24054,7 +24185,9 @@
                 "camelcase": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -24115,7 +24248,6 @@
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
             "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-            "optional": true,
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -24297,7 +24429,9 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "optional": true,
+            "peer": true
         },
         "collect-v8-coverage": {
             "version": "1.0.1",
@@ -24471,7 +24605,9 @@
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "optional": true,
+            "peer": true
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -24977,6 +25113,8 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "array-find-index": "^1.0.1"
             }
@@ -25192,7 +25330,9 @@
         "delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "optional": true,
+            "peer": true
         },
         "depd": {
             "version": "1.1.2",
@@ -25545,7 +25685,9 @@
         "env-paths": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-            "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+            "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+            "optional": true,
+            "peer": true
         },
         "errno": {
             "version": "0.1.8",
@@ -27068,6 +27210,8 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -27083,6 +27227,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
             "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "globule": "^1.0.0"
             }
@@ -27120,7 +27266,9 @@
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "optional": true,
+            "peer": true
         },
         "get-stream": {
             "version": "4.1.0",
@@ -27214,6 +27362,8 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
             "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "glob": "~7.1.1",
                 "lodash": "~4.17.10",
@@ -27283,6 +27433,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             },
@@ -27290,7 +27442,9 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -27312,7 +27466,9 @@
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "optional": true,
+            "peer": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -27966,7 +28122,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "optional": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -28081,12 +28236,16 @@
         "is-finite": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+            "optional": true,
+            "peer": true
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -28226,7 +28385,9 @@
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "optional": true,
+            "peer": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -29222,7 +29383,9 @@
         "js-base64": {
             "version": "2.6.4",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-            "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+            "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+            "optional": true,
+            "peer": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -29440,6 +29603,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -29543,6 +29708,8 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "currently-unhandled": "^0.4.1",
                 "signal-exit": "^3.0.0"
@@ -29616,7 +29783,9 @@
         "map-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "optional": true,
+            "peer": true
         },
         "map-visit": {
             "version": "1.0.0",
@@ -29659,6 +29828,8 @@
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "camelcase-keys": "^2.0.0",
                 "decamelize": "^1.1.2",
@@ -29676,6 +29847,8 @@
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "path-exists": "^2.0.0",
                         "pinkie-promise": "^2.0.0"
@@ -29685,6 +29858,8 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "repeating": "^2.0.0"
                     }
@@ -29693,6 +29868,8 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "pinkie-promise": "^2.0.0"
                     }
@@ -29701,6 +29878,8 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "load-json-file": "^1.0.0",
                         "normalize-package-data": "^2.3.2",
@@ -29711,6 +29890,8 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "find-up": "^1.0.0",
                         "read-pkg": "^1.0.0"
@@ -29720,6 +29901,8 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "indent-string": "^2.1.0",
                         "strip-indent": "^1.0.1"
@@ -29729,6 +29912,8 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "get-stdin": "^4.0.1"
                     }
@@ -30021,7 +30206,9 @@
         "nan": {
             "version": "2.14.2",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "optional": true,
+            "peer": true
         },
         "nanoid": {
             "version": "3.1.22",
@@ -30104,6 +30291,8 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
             "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "env-paths": "^2.2.0",
                 "glob": "^7.1.4",
@@ -30121,6 +30310,8 @@
                     "version": "7.3.4",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
                     "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -30214,6 +30405,8 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
             "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "async-foreach": "^0.1.3",
                 "chalk": "^1.1.1",
@@ -30236,12 +30429,16 @@
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "optional": true,
+                    "peer": true
                 },
                 "chalk": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
                         "escape-string-regexp": "^1.0.2",
@@ -30253,7 +30450,9 @@
                 "supports-color": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -30261,6 +30460,8 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
             "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "abbrev": "1"
             }
@@ -30316,6 +30517,8 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -30339,7 +30542,9 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "optional": true,
+            "peer": true
         },
         "nwsapi": {
             "version": "2.2.0",
@@ -30747,6 +30952,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -32532,7 +32739,6 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
             "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-            "optional": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }
@@ -32677,6 +32883,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "is-finite": "^1.0.0"
             }
@@ -33229,10 +33437,20 @@
             "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
             "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
         },
+        "sass": {
+            "version": "1.42.1",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+            "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
+            "requires": {
+                "chokidar": ">=3.0.0 <4.0.0"
+            }
+        },
         "sass-graph": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
             "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "glob": "^7.0.0",
                 "lodash": "^4.0.0",
@@ -33308,6 +33526,8 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "js-base64": "^2.1.8",
                 "source-map": "^0.4.2"
@@ -33317,6 +33537,8 @@
                     "version": "0.4.4",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "amdefine": ">=0.0.4"
                     }
@@ -33939,6 +34161,8 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
             "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "readable-stream": "^2.0.1"
             }
@@ -34024,6 +34248,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -34098,6 +34324,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "is-utf8": "^0.2.0"
             }
@@ -34611,12 +34839,16 @@
         "trim-newlines": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "optional": true,
+            "peer": true
         },
         "true-case-path": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
             "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "glob": "^7.1.2"
             }
@@ -35982,6 +36214,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "optional": true,
+            "peer": true,
             "requires": {
                 "string-width": "^1.0.2 || 2"
             }

--- a/client/package.json
+++ b/client/package.json
@@ -10,13 +10,13 @@
         "eslint-config-react-app": "^6.0.0",
         "howler": "^2.2.3",
         "moment": "^2.29.1",
-        "node-sass": "5.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.15.2",
         "react-router": "^5.2.1",
         "react-router-dom": "^5.3.0",
-        "react-scripts": "4.0.3"
+        "react-scripts": "4.0.3",
+        "sass": "^1.42.1"
     },
     "scripts": {
         "start": "react-scripts start",


### PR DESCRIPTION
Fixes #89 

Changes proposed in this pull request:
- Removes the deprecated `node-sass` in favor of `sass`

