### PR TITLE
Add emailjs. Update contactForm. Remove api.js and axios

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
                 "@testing-library/jest-dom": "^5.14.1",
                 "@testing-library/react": "^12.0.0",
                 "@testing-library/user-event": "^13.2.1",
-                "axios": "^0.21.4",
+                "emailjs-com": "^3.2.0",
                 "eslint-config-react-app": "^6.0.0",
                 "howler": "^2.2.3",
                 "moment": "^2.29.1",
@@ -3631,14 +3631,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
         "node_modules/axobject-query": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4757,9 +4749,13 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001202",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
-            "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ=="
+            "version": "1.0.30001265",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+            "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/browserslist"
+            }
         },
         "node_modules/capture-exit": {
             "version": "2.0.0",
@@ -6508,6 +6504,14 @@
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "node_modules/emailjs-com": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
+            "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/emittery": {
             "version": "0.7.2",
@@ -23279,14 +23283,6 @@
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
             "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ=="
         },
-        "axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "requires": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
         "axobject-query": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -24203,9 +24199,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001202",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
-            "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ=="
+            "version": "1.0.30001265",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+            "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw=="
         },
         "capture-exit": {
             "version": "2.0.0",
@@ -25619,6 +25615,11 @@
                     "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
                 }
             }
+        },
+        "emailjs-com": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
+            "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA=="
         },
         "emittery": {
             "version": "0.7.2",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.2.1",
-        "axios": "^0.21.4",
+        "emailjs-com": "^3.2.0",
         "eslint-config-react-app": "^6.0.0",
         "howler": "^2.2.3",
         "moment": "^2.29.1",

--- a/client/src/components/ContactForm.js
+++ b/client/src/components/ContactForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from "react";
+import emailjs from "emailjs-com";
 import { useForm } from "react-hook-form";
 
-import api from "../helpers/api";
 import ModalContext from "../contexts/ModalContext";
 
 const ContactForm = () => {
@@ -16,15 +16,19 @@ const ContactForm = () => {
 
     const onSubmit = (data, e) => {
         setIsSubmitting(true);
-        JSON.stringify(data);
-        api.post("/", {
-            subject: "New Message From Website",
-            name: data.name,
-            email: data.email,
-            text: data.question,
-        })
-            .then((res) => {
-                if (res.data.status === "success") {
+        emailjs
+            .send(
+                process.env.REACT_APP_SERVICE_ID,
+                process.env.REACT_APP_TEMPLATE_ID,
+                {
+                    name: data.name,
+                    email: data.email,
+                    question: data.question,
+                },
+                process.env.REACT_APP_USER_ID
+            )
+            .then((response) => {
+                if (response.status === 200) {
                     e.target.reset();
                     setModalHeadingText("Success!");
                     setModalContentText(
@@ -41,7 +45,8 @@ const ContactForm = () => {
                     setIsSubmitting(false);
                 }
             })
-            .catch(() => {
+            .catch((error) => {
+                console.log("FAILED...", error);
                 setModalHeadingText("Error");
                 setModalContentText("Server possibly down");
                 setModalIsOpen(true);

--- a/client/src/helpers/api.js
+++ b/client/src/helpers/api.js
@@ -1,6 +1,0 @@
-import axios from "axios";
-
-export default axios.create({
-    // baseURL: 'http://localhost:4444/sendtome'
-    baseURL: "https://code-experiment-mail-server.herokuapp.com/sendtome",
-});


### PR DESCRIPTION
Fixes #93 

Changes proposed in this pull request:
- Add EmailJS
- Update ContactForm submission to send to EmailJS.
- No need for `api.js` or `axios` anymore since we're not calling the mail server anymore.
- This works great and was easy to add but I still think we should work towards fixing nodemailer in #84 

FYI, this is already deployed on Netlify.  Be mindful we can only send 200 emails a month.